### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - '7.1'
   - '7.2'
+  - '7.3'
 
 install:
   - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "illuminate/support": "~5.2",
         "illuminate/http": "~5.2",
         "illuminate/database": "~5.2"
     },
     "require-dev": {
         "mockery/mockery": "~1.1",
-        "phpunit/phpunit": "5.5.*|6.0.*",
+        "phpunit/phpunit": "7.0.*",
         "orchestra/testbench": "~3.0"
     },
     "autoload": {

--- a/tests/Grammar/FilterGrammarTest.php
+++ b/tests/Grammar/FilterGrammarTest.php
@@ -2,6 +2,7 @@
 
 namespace SehrGut\Eloquery\Tests\Grammar;
 
+use UnexpectedValueException;
 use SehrGut\Eloquery\Grammar\FilterGrammar;
 use SehrGut\Eloquery\Operators;
 
@@ -51,25 +52,25 @@ class FilterGrammarTest extends GrammarTestCase
         ], $result);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function test_it_bails_when_filters_are_not_an_array()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('filter must be an array, eg. [["key" => "someField", "value" => "desiredValue", "operator" => "equals"], […], …');
+
         $this->request->shouldReceive('get')
             ->once()
             ->with('filter')
             ->andReturn('a bad return value');
 
         $grammar = new FilterGrammar();
-        $result = $grammar->extract($this->request);
+        $grammar->extract($this->request);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function test_it_bails_when_key_is_missing_from_filters()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('each filter must contain both key and value');
+
         $this->request->shouldReceive('get')
             ->once()
             ->with('filter')
@@ -82,11 +83,11 @@ class FilterGrammarTest extends GrammarTestCase
         $result = $grammar->extract($this->request);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function test_it_bails_when_value_is_missing_from_filters()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('each filter must contain both key and value');
+
         $this->request->shouldReceive('get')
             ->once()
             ->with('filter')
@@ -99,11 +100,11 @@ class FilterGrammarTest extends GrammarTestCase
         $result = $grammar->extract($this->request);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function test_it_bails_when_operator_is_invalid()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid filter operator (BOGUS). Must be one of (EQUALS, CONTAINS, STARTS_WITH, ENDS_WITH, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, IN, BETWEEN)');
+
         $this->request->shouldReceive('get')
             ->once()
             ->with('filter')

--- a/tests/Grammar/GrammarTestCase.php
+++ b/tests/Grammar/GrammarTestCase.php
@@ -10,7 +10,7 @@ class GrammarTestCase extends TestCase
 {
     protected $request;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Grammar/PaginateGrammarTest.php
+++ b/tests/Grammar/PaginateGrammarTest.php
@@ -2,8 +2,6 @@
 
 namespace SehrGut\Eloquery\Tests\Grammar;
 
-use Illuminate\Http\Request;
-use Mockery;
 use SehrGut\Eloquery\Grammar\PaginateGrammar;
 
 class PaginateGrammarTest extends GrammarTestCase
@@ -26,6 +24,7 @@ class PaginateGrammarTest extends GrammarTestCase
             'page' => 3,
         ], $result);
     }
+
     public function test_it_cant_exceed_the_maximum_value_for_limit()
     {
         $this->request->shouldReceive('get')

--- a/tests/Grammar/SortGrammarTest.php
+++ b/tests/Grammar/SortGrammarTest.php
@@ -2,6 +2,7 @@
 
 namespace SehrGut\Eloquery\Tests\Grammar;
 
+use UnexpectedValueException;
 use SehrGut\Eloquery\Grammar\SortGrammar;
 
 class SortGrammarTest extends GrammarTestCase
@@ -51,11 +52,11 @@ class SortGrammarTest extends GrammarTestCase
         ], $result);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function test_it_bails_when_sorts_are_not_an_array()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('sort must be an array, eg. [["key" => "someField", "direction" => "desc"], […], …');
+
         $this->request->shouldReceive('get')
             ->once()
             ->with('sort')
@@ -65,11 +66,11 @@ class SortGrammarTest extends GrammarTestCase
         $result = $grammar->extract($this->request);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function test_it_bails_when_key_is_missing_from_sorts()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Each sort order must at least specify a key.');
+
         $this->request->shouldReceive('get')
             ->once()
             ->with('sort')
@@ -82,11 +83,11 @@ class SortGrammarTest extends GrammarTestCase
         $result = $grammar->extract($this->request);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function test_it_bails_when_direction_is_invalid()
     {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('direction must be either "asc" or "desc" (or omitted)');
+
         $this->request->shouldReceive('get')
             ->once()
             ->with('sort')

--- a/tests/OperationResultTest.php
+++ b/tests/OperationResultTest.php
@@ -3,7 +3,6 @@
 namespace SehrGut\Eloquery\Tests;
 
 use SehrGut\Eloquery\OperationResult;
-use SehrGut\Eloquery\Operators;
 
 class OperationResultTest extends TestCase
 {

--- a/tests/Operations/FilterTest.php
+++ b/tests/Operations/FilterTest.php
@@ -6,17 +6,18 @@ use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Mockery;
+use InvalidArgumentException;
 use SehrGut\Eloquery\Operations\Filter;
 use SehrGut\Eloquery\Operators;
 
 class FilterTest extends OperationTestCase
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function test_it_throws_an_exception_on_invalid_operator()
     {
-        $filter = new Filter('field', 'value', 'non-exisiting-operator', false);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid operator: non-exisiting-operator');
+
+        new Filter('field', 'value', 'non-exisiting-operator', false);
     }
 
     public function test_it_applies_equals_constraint()

--- a/tests/Operations/OperationCollectionTest.php
+++ b/tests/Operations/OperationCollectionTest.php
@@ -4,16 +4,16 @@ namespace SehrGut\Eloquery\Tests\Operations;
 
 use Illuminate\Database\Eloquent\Builder;
 use Mockery;
+use TypeError;
 use SehrGut\Eloquery\Contracts\Operation;
 use SehrGut\Eloquery\OperationCollection;
 
 class OperationCollectionTest extends OperationTestCase
 {
-    /**
-     * @expectedException TypeError
-     */
     public function test_it_rejects_non_operation_items()
     {
+        $this->expectException(TypeError::class);
+
         new OperationCollection(['foo']);
     }
 

--- a/tests/Operations/OperationTestCase.php
+++ b/tests/Operations/OperationTestCase.php
@@ -10,7 +10,7 @@ class OperationTestCase extends TestCase
 {
     protected $builder;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,7 @@ class TestCase extends PhpUnitTestCase
         return require __DIR__ . '/../config/eloquery.php';
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         if ($container = Mockery::getContainer()) {


### PR DESCRIPTION
# Changed log
- Add the `php-7.3` test on Travis CI build.
- Let the PHP package require `php-7.1+` version at least because some approaches on source code are only available on `php-7.1` version.
It defines in `composer.json`.
- Drop the PHPUnit `5.5.*` version and upgrade to the PHPUnit `7.*` because it requires `php-7.1+` version at least.
- Remove the unused `class namespace` declaration via `use` syntax.
- Replace the `expectedException` annotation with method-based `expectException` because the PHPUnit `5.5.*` was dropped in `composer.json`.
- According to the [Fixtures](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures) reference, the `PHPUnit\Framework\TestCase::setUp` and `tearDown` methods should be `protected`, not `public`.